### PR TITLE
Use the new scriptDataDir variable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         },
         "node_modules/@crowbartools/firebot-custom-scripts-types": {
             "version": "5.64.0",
-            "resolved": "git+ssh://git@github.com/TheStaticMage/firebot-custom-scripts-types.git#8c6aaf34c3341597cd4bf8e31836e08a4be91e02",
+            "resolved": "git+ssh://git@github.com/TheStaticMage/firebot-custom-scripts-types.git#ab15e53918e57d4db1560a4ec07b998a3fdd7051",
             "license": "ISC",
             "dependencies": {
                 "@twurple/api": "^7.2.1",
@@ -3699,6 +3699,12 @@
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
             }
+        },
+        "node_modules/upgrade": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/upgrade/-/upgrade-1.1.0.tgz",
+            "integrity": "sha512-NtkVvqVCqsJo5U3mYRum2Tw6uCltOxfIJ/AfTZeTmw6U39IB5X23xF+kRZ9aiPaORqeiQQ7Q209/ibhOvxzwHA==",
+            "license": "MIT"
         },
         "node_modules/uri-js": {
             "version": "4.4.1",

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -7,11 +7,11 @@ import { GameManager } from './game';
 import { getQuestionManager, QuestionManager } from './questions/common';
 import { registerReplaceVariables } from './variables';
 
-declare const SCRIPTS_DIR: string;
-
 export let triviaGame: TriviaGame;
 
-const usedQuestionsPath = 'firebot-mage-trivia-data/used-questions.json';
+const usedQuestionsFile = 'used-questions.json';
+const usedQuestionsPath = `script-data/firebot-mage-trivia/${usedQuestionsFile}`; // Old path for compatibility
+declare const SCRIPTS_DIR: string; // Old method for compatibility
 
 export class TriviaGame {
     private gameManager: GameManager;
@@ -40,16 +40,16 @@ export class TriviaGame {
         try {
             // Requires a version of Firebot that exposes the profile manager.
             // See https://github.com/crowbartools/Firebot/issues/3180
-            const { profileManager } = this.getFirebotManager().getModules();
-            const result = profileManager.getPathInProfile(usedQuestionsPath);
-            logger('debug', `Got used question persistence path from profile manager: ${result}`);
+            const { path, scriptDataDir } = this.getFirebotManager().getModules();
+            const result = path.join(scriptDataDir, usedQuestionsFile);
+            logger('debug', `Got used question persistence path from scriptDataDir: ${scriptDataDir}`);
             return result;
         } catch (error) {
-            // Fall back to the alternate method if the above fails
+            // Fall back to the legacy method, compatible with older versions of Firebot.
             const profileDirectory = path.join(SCRIPTS_DIR, '..');
             const usedQuestionsPathSplit = usedQuestionsPath.split('/');
             const result = path.join(profileDirectory, ...usedQuestionsPathSplit);
-            logger('debug', `Got used question persistence path from alternate method: ${result} (error: ${error})`);
+            logger('debug', `Got used question persistence path from legacy method: ${result} (error: ${error})`);
             return result;
         }
     }

--- a/src/questions/local.ts
+++ b/src/questions/local.ts
@@ -3,7 +3,6 @@ import { createHash } from 'crypto';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 import * as NodeCache from 'node-cache';
-import * as path from 'path';
 import { logger } from '../firebot';
 import { TriviaGame } from '../globals';
 import { ErrorType, reportError } from '../util/errors';
@@ -136,6 +135,7 @@ export class LocalQuestionManager extends QuestionManager {
             return;
         }
 
+        const { path } = this.triviaGame.getFirebotManager().getModules();
         const file: string = path.basename(filePath, path.extname(filePath));
         const questionMap = new Map<string, Question>();
 
@@ -222,9 +222,10 @@ export class LocalQuestionManager extends QuestionManager {
 
         await this.fileMutex.runExclusive(async (): Promise<void> => {
             try {
+                const { path } = this.triviaGame.getFirebotManager().getModules();
                 const usedQuestionsFileDir = path.dirname(usedQuestionsFilePath);
                 if (!fs.existsSync(usedQuestionsFileDir)) {
-                    fs.mkdirSync(usedQuestionsFileDir);
+                    fs.mkdirSync(usedQuestionsFileDir, { recursive: true });
                     logger('debug', `Created directory for used questions file: ${usedQuestionsFileDir}`);
                 }
 


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description

Support for a `scriptDataDir` variable was added to upstream Firebot, so I can replace the existing implementation which was based on an originally proposed solution that was ultimately revised.

- https://github.com/crowbartools/Firebot/issues/3180
- https://github.com/crowbartools/firebot-custom-scripts-types/pull/49

The legacy method with the `SCRIPTS_DIR` global is still there for backward compatibility, and this still has to point at my own branch of `firebot-custom-scripts-types` until the PR there is merged.

### Motivation

Keep the code in this script aligned with upstream Firebot. The previous implementation is not ever going to happen.

### Testing

Confirmed that the correct directory path is being chosen via the "new" method by examining debug logs of Firebot, and confirming that the used question trivia file is read from and written to the new path.
