### PR TITLE
Add events for answer correct and answer incorrect

### DIFF
--- a/doc/reference/events.md
+++ b/doc/reference/events.md
@@ -1,6 +1,8 @@
 # Reference: Events
 
 - [Answer Accepted Timer Fired](#answer-accepted-timer-fired)
+- [Answer Correct](#answer-correct)
+- [Answer Incorrect](#answer-incorrect)
 - [Answer Rejected](#answer-rejected)
 - [Critical Error](#critical-error)
 - [Game Cancelled](#game-cancelled)
@@ -42,6 +44,73 @@ Because the event does not fire if nobody has answered the question since the la
 - When setting `$mageTriviaAnswerAccepted`, if the user has been reported in a previous event but then changed their answer since the last event, the user will again be reported in the firing event.
 - When setting `$mageTriviaAnswerAccepted`, users are alphabetized.
 - When setting `$mageTriviaAnswerAccepted`, the user display name (username with preferred capitalization) is used if available.
+
+## Answer Correct
+
+#### Description
+
+This event fires once for each user who answered the question correctly, once the game has ended.
+
+#### Handling this Event
+
+This event might be used to record user-specific information or statistics. For example:
+
+- Updating lifetime trivia statistics in the user's metadata.
+- Updating a counter of total correct trivia answers given in the stream.
+- Registering credit for the closing credits role with the [Mage Credits Generator](https://github.com/TheStaticMage/firebot-mage-credits-generator)
+
+#### Variables
+
+Sets [`$mageTriviaAnswerAmount`](/doc/reference/variables.md#) to the amount of currency the player was awarded.
+
+Sets [`$mageTriviaAnswerIndex`](/doc/reference/variables.md#) to the text of the answer that was given by the player (e.g. 0).
+
+Sets [`$mageTriviaAnswerLetter`](/doc/reference/variables.md#) to the letter of the answer that was given by the player (e.g. A, B, C, or D).
+
+Sets [`$mageTriviaAnswerUsername`](/doc/reference/variables.md#) to the username of the player.
+
+#### Notes & Limitations
+
+- This is an advanced event that most users will not handle. The trivia game will work just fine without it.
+- The [Game Ended](#game-ended) event is the best place to chat out the correct answer and a summary of the winners. To avoid Twitch rate limits, it is not recommended to chat as part of handling this event.
+- This event will always be emitted _after_ the [Game Ended](#game-ended) event.
+- This event will not be emitted if the game is cancelled.
+- Currency is automatically adjusted by the game. You do not need to handle currency adjustments in this event.
+- You can use `$mageTriviaAnswerIndex` in conjunction with [`$mageTriviaAnswers`](/doc/reference/variables.md#magetriviaanswers) to identify the text of the answer that the user provided.
+- Other events have already set [`$mageTriviaCorrectAnswers`](/doc/reference/variables.md#magetriviacorrectanswers) which may be useful.
+
+## Answer Incorrect
+
+#### Description
+
+This event fires once for each user who answered the question incorrectly, once the game has ended.
+
+#### Handling this Event
+
+This event might be used to record user-specific information or statistics. For example:
+
+- Updating lifetime trivia statistics in the user's metadata.
+- Updating a counter of total incorrect trivia answers given in the stream.
+
+#### Variables
+
+Sets [`$mageTriviaAnswerAmount`](/doc/reference/variables.md#) to the amount of currency the player was penalized. (This will be reported as a positive number, but note that it was _subtracted_ from the user's balance.)
+
+Sets [`$mageTriviaAnswerIndex`](/doc/reference/variables.md#) to the text of the answer that was given by the player (e.g. 0).
+
+Sets [`$mageTriviaAnswerLetter`](/doc/reference/variables.md#) to the letter of the answer that was given by the player (e.g. A, B, C, or D).
+
+Sets [`$mageTriviaAnswerUsername`](/doc/reference/variables.md#) to the username of the player.
+
+#### Notes & Limitations
+
+- This is an advanced event that most users will not handle. The trivia game will work just fine without it.
+- The [Game Ended](#game-ended) event is the best place to chat out the correct answer and a summary of the winners. To avoid Twitch rate limits, it is not recommended to chat as part of handling this event.
+- This event will always be emitted _after_ the [Game Ended](#game-ended) event.
+- This event will not be emitted if the game is cancelled.
+- Currency is automatically adjusted by the game. You do not need to handle currency adjustments in this event.
+- You can use `$mageTriviaAnswerIndex` in conjunction with [`$mageTriviaAnswers`](/doc/reference/variables.md#magetriviaanswers) to identify the text of the answer that the user provided.
+- Other events have already set [`$mageTriviaCorrectAnswers`](/doc/reference/variables.md#magetriviacorrectanswers) which may be useful.
 
 ## Answer Rejected
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -6,6 +6,8 @@ export const TRIVIA_EVENT_SOURCE_NAME = "Mage Trivia Events";
 
 export enum TriviaEvent {
     ANSWER_ACCEPTED = "triviaAnswerAccepted",
+    ANSWER_CORRECT = "triviaAnswerCorrect",
+    ANSWER_INCORRECT = "triviaAnswerIncorrect",
     ANSWER_REJECTED = "triviaAnswerRejected",
     ERROR_CRITICAL = "triviaErrorCritical",
     ERROR_RUNTIME = "triviaErrorRuntime",
@@ -43,6 +45,13 @@ export type AnswerRejectedMetadata = {
     reasonMessage: string;
 }
 
+export type AnswerCorrectIncorrectMetadata = {
+    username: string;
+    answer: string;
+    answerIndex: number;
+    amount: number; // The amount of points won or lost
+}
+
 /**
  * Metadata for a critical error or runtime error (TRIVIA_ERROR_CRITICAL_EVENT or TRIVIA_ERROR_RUNTIME_EVENT)
  */
@@ -75,6 +84,28 @@ const eventSource: EventSource = {
             id: TriviaEvent.ANSWER_ACCEPTED,
             name: "Answer Accepted Timer Fired",
             description: "Fires on a periodic basis while a game is in progress to acknowledge accepted answers."
+        },
+        {
+            id: TriviaEvent.ANSWER_CORRECT,
+            name: "Answer Correct",
+            description: "Fires when the trivia game ends and a user answered the question correctly.",
+            manualMetadata: {
+                username: "firebot",
+                answer: "A",
+                answerIndex: 0,
+                amount: 100
+            }
+        },
+        {
+            id: TriviaEvent.ANSWER_INCORRECT,
+            name: "Answer Incorrect",
+            description: "Fires when the trivia game ends and a user answered the question incorrectly.",
+            manualMetadata: {
+                username: "firebot",
+                answer: "B",
+                answerIndex: 1,
+                amount: 50
+            }
         },
         {
             id: TriviaEvent.ANSWER_REJECTED,

--- a/src/variables/answer-results.ts
+++ b/src/variables/answer-results.ts
@@ -1,0 +1,84 @@
+import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
+import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
+import { AnswerCorrectIncorrectMetadata, TRIVIA_EVENT_SOURCE_ID, TriviaEvent } from '../events';
+import { logger } from '../firebot';
+
+export const mageTriviaAnswerAmount: ReplaceVariable = {
+    definition: {
+        handle: "mageTriviaAnswerAmount",
+        description: "Returns the amount of points a user won or lost for the 'Answer Correct' and 'Answer Incorrect' events.",
+        possibleDataOutput: ["number"],
+        triggers: {
+            "manual": true,
+            "event": [`${TRIVIA_EVENT_SOURCE_ID}:${TriviaEvent.ANSWER_CORRECT}`, `${TRIVIA_EVENT_SOURCE_ID}:${TriviaEvent.ANSWER_INCORRECT}`]
+        }
+    },
+    evaluator: async (trigger: Effects.Trigger) => {
+        const eventData = trigger.metadata?.eventData as AnswerCorrectIncorrectMetadata;
+        if (!eventData) {
+            logger('warn', 'Called mageTriviaAnswerAmount variable without expected metadata.');
+            return 0;
+        }
+        return eventData.amount;
+    }
+};
+
+export const mageTriviaAnswerIndex: ReplaceVariable = {
+    definition: {
+        handle: "mageTriviaAnswerIndex",
+        description: "Returns the index of the answer a user selected for the 'Answer Correct' and 'Answer Incorrect' events.",
+        possibleDataOutput: ["number"],
+        triggers: {
+            "manual": true,
+            "event": [`${TRIVIA_EVENT_SOURCE_ID}:${TriviaEvent.ANSWER_CORRECT}`, `${TRIVIA_EVENT_SOURCE_ID}:${TriviaEvent.ANSWER_INCORRECT}`]
+        }
+    },
+    evaluator: async (trigger: Effects.Trigger) => {
+        const eventData = trigger.metadata?.eventData as AnswerCorrectIncorrectMetadata;
+        if (!eventData) {
+            logger('warn', 'Called mageTriviaAnswerIndex variable without expected metadata.');
+            return 0;
+        }
+        return eventData.answerIndex;
+    }
+};
+
+export const mageTriviaAnswerLetter: ReplaceVariable = {
+    definition: {
+        handle: "mageTriviaAnswerLetter",
+        description: "Returns the letter of the answer a user selected for the 'Answer Correct' and 'Answer Incorrect' events.",
+        possibleDataOutput: ["text"],
+        triggers: {
+            "manual": true,
+            "event": [`${TRIVIA_EVENT_SOURCE_ID}:${TriviaEvent.ANSWER_CORRECT}`, `${TRIVIA_EVENT_SOURCE_ID}:${TriviaEvent.ANSWER_INCORRECT}`]
+        }
+    },
+    evaluator: async (trigger: Effects.Trigger) => {
+        const eventData = trigger.metadata?.eventData as AnswerCorrectIncorrectMetadata;
+        if (!eventData) {
+            logger('warn', 'Called mageTriviaAnswerLetter variable without expected metadata.');
+            return "";
+        }
+        return eventData.answer;
+    }
+};
+
+export const mageTriviaAnswerUsername: ReplaceVariable = {
+    definition: {
+        handle: "mageTriviaAnswerUsername",
+        description: "Returns the username of the user who answered for the 'Answer Correct' and 'Answer Incorrect' events.",
+        possibleDataOutput: ["text"],
+        triggers: {
+            "manual": true,
+            "event": [`${TRIVIA_EVENT_SOURCE_ID}:${TriviaEvent.ANSWER_CORRECT}`, `${TRIVIA_EVENT_SOURCE_ID}:${TriviaEvent.ANSWER_INCORRECT}`]
+        }
+    },
+    evaluator: async (trigger: Effects.Trigger) => {
+        const eventData = trigger.metadata?.eventData as AnswerCorrectIncorrectMetadata;
+        if (!eventData) {
+            logger('warn', 'Called mageTriviaAnswerUsername variable without expected metadata.');
+            return "";
+        }
+        return eventData.username;
+    }
+};

--- a/src/variables/index.ts
+++ b/src/variables/index.ts
@@ -1,4 +1,5 @@
 import { TriviaGame } from '../globals';
+import { mageTriviaAnswerAmount, mageTriviaAnswerIndex, mageTriviaAnswerLetter, mageTriviaAnswerUsername } from './answer-results';
 import { arrayJoinWith } from './array-join-with';
 import { mageTriviaError, mageTriviaErrorFull } from './errors';
 import { mageTriviaGameInProgress, mageTriviaGameTimeRemaining } from './game-status';
@@ -22,4 +23,8 @@ export function registerReplaceVariables(triviaGame: TriviaGame): void {
     triviaGame.getFirebotManager().registerReplaceVariable(mageTriviaGameResultsRaw);
     triviaGame.getFirebotManager().registerReplaceVariable(mageTriviaWinners);
     triviaGame.getFirebotManager().registerReplaceVariable(mageTriviaWinnersWithPoints);
+    triviaGame.getFirebotManager().registerReplaceVariable(mageTriviaAnswerUsername);
+    triviaGame.getFirebotManager().registerReplaceVariable(mageTriviaAnswerAmount);
+    triviaGame.getFirebotManager().registerReplaceVariable(mageTriviaAnswerIndex);
+    triviaGame.getFirebotManager().registerReplaceVariable(mageTriviaAnswerLetter);
 }


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This creates Answer Correct and Answer Incorrect events, which fire for each correct/incorrect answer at the end of a trivia question.

### Motivation
This makes it possible, for example, to add a user's trivia statistics to their meta or another tracking system, without looping through an object.

### Testing
Added these to my firebot and tested along with the [credit generator](https://github.com/TheStaticMage/firebot-mage-credits-generator) to recognize the top trivia players of a screen in my closing credits.
