### PR TITLE
Version bump opens draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - "*"
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 jobs:
   build:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -56,7 +56,7 @@ jobs:
           body: "This PR bumps the version to ${{ steps.bump_version.outputs.next-version }}."
           branch: "bump-version-${{ steps.bump_version.outputs.next-version }}"
           base: main
-          draft: false
+          draft: always-true
           labels: 'ignore-for-release'
           add-paths: |
             package.json


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This causes the "version bump" action to open its PRs as drafts, this allowing the CI actions to run when the PR is marked as ready for review

### Motivation
Documented workaround for GitHub actions generated PRs not running CI on themselves.

### Testing
<!-- Outline any testing you've done for these changes. You may provide screen shots, copy/paste from logs, etc. as evidence. -->
