### PR TITLE
Trigger lint CI job upon exiting from draft

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - "*"
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 jobs:
   lint:


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
This will make the lint action trigger when the PR is taken out of draft.

### Motivation
Same as https://github.com/TheStaticMage/firebot-mage-trivia/pull/14 - we need to have the lint job trigger too.

### Testing
<!-- Outline any testing you've done for these changes. You may provide screen shots, copy/paste from logs, etc. as evidence. -->
