### PR TITLE
Add filtering to answer accepted variable

### DIFF
--- a/doc/reference/variables.md
+++ b/doc/reference/variables.md
@@ -57,6 +57,12 @@ This is an array of users (with preferred capitalization when possible) who have
 
 This is commonly used to acknowledge answers in chat (see the example). This is implemented due to rate limits in the Twitch API where sending a chat message to acknowledge each user's response would eventually result in errors, and make the chat very noisy.
 
+It is possible one or more `key=value` arguments to this variable to filter results. Accepted filters are:
+
+- `username=<username>`
+- `userDisplayName=<user display name>`
+- `platform=twitch` or `platform=kick` (if you are using the [Kick Integration](https://github.com/TheStaticMage/firebot-mage-kick-integration))
+
 #### Usage & Examples
 
 `$mageTriviaAnswerAccepted => Array`
@@ -71,6 +77,18 @@ This is most commonly used to acknowledge answers in chat when the [Answer Accep
 ```
 Accepted answers for $arrayJoinWith[$mageTriviaAnswerAccepted, "and"]!
 => Accepted answers for TheStaticMage and TheStaticBrock!
+```
+
+Here is an example with the [Kick Integration](https://github.com/TheStaticMage/firebot-mage-kick-integration) to filter by platform:
+
+```
+$mageTriviaAnswerAccepted[platform=twitch]
+```
+
+This example indicates how you can use multiple filters at once. This example is a bit contrived, however, as there are better ways to see of an element is in the array.
+
+```
+$mageTriviaAnswerAccepted[platform=twitch,username=thestaticmage]
 ```
 
 #### Notes & Limitations

--- a/src/events.ts
+++ b/src/events.ts
@@ -30,8 +30,14 @@ export enum AnswerRejectionReason {
 /**
  * Metadata for an answer that was accepted (TRIVIA_ANSWER_ACCEPTED_EVENT)
  */
+export type AnswerAcceptedMetadataEntry = {
+    username: string;
+    userDisplayName: string;
+    trigger: Effects.Trigger | undefined;
+}
+
 export type AnswerAcceptedMetadata = {
-    usernames: string[];
+    entries: AnswerAcceptedMetadataEntry[];
 }
 
 /**

--- a/src/variables/user-answer.test.ts
+++ b/src/variables/user-answer.test.ts
@@ -1,0 +1,82 @@
+import { mageTriviaAnswerAccepted } from './user-answer';
+
+jest.mock('../firebot', () => ({
+    logger: jest.fn()
+}));
+
+describe('mageTriviaAnswerAccepted.evaluator', () => {
+    it('returns empty array if metadata.entries is undefined', async () => {
+        const trigger = { metadata: {} };
+        const result = await mageTriviaAnswerAccepted.evaluator(trigger as any);
+        expect(result).toEqual([]);
+    });
+
+    const baseTrigger = {
+        metadata: {
+            eventData: {
+                entries: [
+                    {
+                        username: 'alice',
+                        userDisplayName: 'Alice',
+                        trigger: { metadata: { platform: 'twitch' } }
+                    },
+                    {
+                        username: 'bob',
+                        userDisplayName: 'Bob',
+                        trigger: { metadata: { platform: 'kick' } }
+                    },
+                    {
+                        username: 'carol',
+                        userDisplayName: 'Carol',
+                        trigger: { metadata: { platform: 'twitch' } }
+                    }
+                ]
+            }
+        }
+    };
+
+    it('returns all user display names sorted by name', async () => {
+        const result = await mageTriviaAnswerAccepted.evaluator(baseTrigger as any);
+        expect(result).toEqual(['Alice', 'Bob', 'Carol']);
+    });
+
+    it('should ignore unrecognized filters and return all answers', async () => {
+        const result = await mageTriviaAnswerAccepted.evaluator(baseTrigger as any, 'unknown=something');
+        expect(result).toEqual(['Alice', 'Bob', 'Carol']);
+    });
+
+    it('filters by username', async () => {
+        const result = await mageTriviaAnswerAccepted.evaluator(baseTrigger as any, 'username=alice');
+        expect(result).toEqual(['Alice']);
+    });
+
+    it('filters by userDisplayName', async () => {
+        const result = await mageTriviaAnswerAccepted.evaluator(baseTrigger as any, 'userDisplayName=Bob');
+        expect(result).toEqual(['Bob']);
+    });
+
+    it('filters by platform', async () => {
+        const result = await mageTriviaAnswerAccepted.evaluator(baseTrigger as any, 'platform=twitch');
+        expect(result).toEqual(['Alice', 'Carol']);
+    });
+
+    it('filters by multiple filters (platform and username)', async () => {
+        const result = await mageTriviaAnswerAccepted.evaluator(baseTrigger as any, 'platform=twitch', 'username=carol');
+        expect(result).toEqual(['Carol']);
+    });
+
+    it('returns an empty array when a valid filter matches no entries', async () => {
+        const result = await mageTriviaAnswerAccepted.evaluator(baseTrigger as any, 'username=nonexistent');
+        expect(result).toEqual([]);
+    });
+
+    it('ignores arguments that are not formatted as key=value', async () => {
+        const result = await mageTriviaAnswerAccepted.evaluator(baseTrigger as any, 'notAFilter');
+        expect(result).toEqual(['Alice', 'Bob', 'Carol']);
+    });
+
+    it('trims leading and trailing whitespace around key and value in filter arguments', async () => {
+        const result = await mageTriviaAnswerAccepted.evaluator(baseTrigger as any, '  username = alice  ');
+        expect(result).toEqual(['Alice']);
+    });
+});


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Adds the ability to filter `$mageTriviaAnswerAccepted` based on username, user display name, or platform.

### Motivation
This allows separate acknowledgements to Twitch and Kick if one is using my Kick integration. And possibly other benefits too.

### Testing
Unit tests and I separated my "Answer Accepted" events by platform and tested with my channels.
