### PR TITLE
Mark full error variable as sensitive (5.65+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,13 @@ Feel free to stop by my Twitch stream (<https://www.twitch.tv/thestaticmage>) wh
 
 ## Installation
 
-1. From the latest [Release](https://github.com/TheStaticMage/firebot-mage-trivia/releases), download `Firebot-MageTrivia-<version>.js` into your Firebot scripts directory (File &gt; Open Data Folder, then select the "scripts" directory).
+:warning: Mage Trivia version 0.1.0 and later require Firebot 5.65 or later. Strongly consider updating Firebot to the latest version. (If you must use Firebot 5.64, install Mage Trivia 0.0.4.)
 
-    :warning: If you are upgrading from a prior version, delete any older versions of this script.
+1. Enable custom scripts in Firebot (Settings &gt; Scripts) if you have not already done so.
 
-2. Enable custom scripts in Firebot (Settings &gt; Scripts).
+2. From the latest [Release](https://github.com/TheStaticMage/firebot-mage-trivia/releases), download `Firebot-MageTrivia-<version>.js` into your Firebot scripts directory (File &gt; Open Data Folder, then select the "scripts" directory).
 
 3. Add the `Firebot-MageTrivia-<version>.js` script that you just added as a startup script (Settings &gt; Scripts &gt; Manage Startup Scripts &gt; Add New Script).
-
-    :warning: If you are upgrading from a prior version, delete any references to the older versions.
 
 4. Restart Firebot.
 
@@ -91,7 +89,7 @@ Feel free to stop by my Twitch stream (<https://www.twitch.tv/thestaticmage>) wh
 The best way to get help is in my Discord server. Join the [The Static Discord](https://discord.gg/TmvGn3ywws) and then visit the `#firebot-mage-trivia` channel there.
 
 - Please do not DM me on Discord.
-- Please do not ask for help in my chat when I am live on Twitch.
+- Please do not ask for help in my chat when I am streaming.
 
 Bug reports and feature requests are welcome via [GitHub Issues](https://github.com/TheStaticMage/firebot-mage-trivia/issues).
 

--- a/doc/reference/events.md
+++ b/doc/reference/events.md
@@ -161,21 +161,19 @@ Critical error events are fired in these situations:
 You should handle this event in a way that will get the your attention, for example:
 
 - If you use the Firebot dashboard, use a Chat Feed Alert or Activity Feed Alert
-    - Example: `$mageTriviaError: $mageTriviaErrorFullDONOTUSETHISINCHAT`
+    - Example: `$mageTriviaError: $mageTriviaErrorFull`
 - Play a sound that only you can hear
 - As a last resort, you could post to your chat
     - It is safe to post `$mageTriviaError` in chat.
-    - :warning: NEVER post `$mageTriviaErrorFullDONOTUSETHISINCHAT` in chat because it could contain sensitive information.
+    - :warning: NEVER post `$mageTriviaErrorFull` in chat because it could contain sensitive information.
 
 #### Variables
 
 Sets [`$mageTriviaError`](/doc/reference/variables.md#magetriviaerror) to a string with a basic error message.
 
-Sets [`$mageTriviaErrorFullDONOTUSETHISINCHAT`](/doc/reference/variables.md#magetriviaerrorfull_do_not_use_this_in_chat) to a string with a more detailed error message.
+Sets [`$mageTriviaErrorFull`](/doc/reference/variables.md#magetriviaerrorfull) to a string with a more detailed error message.
 
 - This detailed error message sometimes contains the full error from the operating system, which can be very handy for debugging, but which can sometimes contain sensitive information. You should never use this variable in any message posted to your chat.
-
-- This detailed error message must be enabled in [settings](/doc/reference/settings.md#enable-the-magetriviaerrorfull_do_not_use_this_in_chat-variable) (to make absolutely sure you are aware of what it contains).
 
 ## Game Cancelled
 

--- a/doc/reference/settings.md
+++ b/doc/reference/settings.md
@@ -203,15 +203,3 @@ When checked, the "used question cache" is written to a file to preserve the sta
 This setting only applies for Trivia Source = File.
 
 This setting controls what happens when all of the questions in the question file have been asked. When checked, the "used question cache" will reset, making all of the questions eligible to be asked again. If this option is unchecked, an error will be logged when the program has run out of questions, and it will not be possible to ask a new question. Most people will want to leave this checked to ensure smooth operation of the program.
-
-### Enable the $mageTriviaErrorFullDONOTUSETHISINCHAT variable
-
-This variable is explained in greater detail:
-
-- [Critical Error event](/doc/reference/events.md#critical-error)
-- [Runtime Error event](/doc/reference/events.md#runtime-error)
-- [`$mageTriviaErrorFullDONOTUSETHISINCHAT` variable](/doc/reference/variables.md#magetriviaerrorfull_do_not_use_this_in_chat)
-
-This variable may contain full error messages from the operating system. This is super helpful information for you to have when fixing any problem. However, these messages might contain sensitive information, like directory or file names, which might have your actual name in them. It is therefore extremely unsafe to post this variable in chat (or use it in any other way where a viewer of your stream might see it).
-
-We force you to check this box as an extra precaution to make sure you understand the implications -- as if the variable name itself wasn't enough...

--- a/doc/reference/variables.md
+++ b/doc/reference/variables.md
@@ -204,23 +204,21 @@ This variable is only available for the _Critial Error_ and _Runtime Error_ even
 
 Although we do not recommend posting these error messages in chat, this variable will contain only pre-determined messages that will not leak information such as file paths that could dox the streamer.
 
-## `$mageTriviaErrorFullDONOTUSETHISINCHAT`
+## `$mageTriviaErrorFull`
 
 #### Description
 
 This is a string with the error message from the [Critical Error](/doc/reference/events.md#critical-error) or [Runtime Error](/doc/reference/events.md#runtime-error) event.
 
-If enabled in [advanced settings](/doc/reference/settings.md#enable-the-magetriviaerrorfull_do_not_use_this_in_chat-variable), it will include more details about the error, including the exact error from the operating system. (If you have not enabled it in the advanced settings, this will be equivalent to [`$mageTriviaError`](#magetriviaerror). This is for your safety.)
-
-:warning: **As the name implies, NEVER use this variable in a message that you are posting to your chat. The error message might include something like a file path, which could include some or all of your name, and therefore "dox" you.**
+:warning: **This variable can contain sensitive information. NEVER use this variable in a message that you are posting to your chat. The error message might include something like a file path, which could include some or all of your name, and therefore "dox" you.**
 
 #### Usage & Examples
 
-```
+```text
 // Only when handling Critical Error or Runtime Error
-$mageTriviaErrorFullDONOTUSETHISINCHAT => String
+$mageTriviaErrorFull => String
 
-$mageTriviaErrorFullDONOTUSETHISINCHAT
+$mageTriviaErrorFull
 => Error reading trivia file: /home/your-real-name-here/trivia.yaml: Error: ENOENT: no such file or directory, open '/home/your-real-name-here/trivia.yaml'
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "firebot-mage-trivia",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "firebot-mage-trivia",
-            "version": "0.0.4",
+            "version": "0.1.0",
             "license": "GNU3",
             "dependencies": {
                 "@crowbartools/firebot-custom-scripts-types": "github:TheStaticMage/firebot-custom-scripts-types#running",
@@ -584,7 +584,7 @@
         },
         "node_modules/@crowbartools/firebot-custom-scripts-types": {
             "version": "5.65.0",
-            "resolved": "git+ssh://git@github.com/TheStaticMage/firebot-custom-scripts-types.git#a2c4f018ffe6cf0d3f70d8b0f39f90b806e14e0c",
+            "resolved": "git+ssh://git@github.com/TheStaticMage/firebot-custom-scripts-types.git#90d1a1ea63ae7557ac0e0fbf99e5e96aff15f640",
             "license": "ISC",
             "dependencies": {
                 "@twurple/api": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "firebot-mage-trivia",
     "scriptOutputName": "Firebot-MageTrivia",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Multiplayer trivia game for Firebot",
     "main": "",
     "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { FirebotManager } from './firebot';
 import { TriviaGame } from './globals';
 import { gameSettings } from './settings';
 
-const scriptVersion = '0.0.4';
+const scriptVersion = '0.1.0';
 
 const script: Firebot.CustomScript<object> = {
     getScriptManifest: () => {
@@ -20,6 +20,21 @@ const script: Firebot.CustomScript<object> = {
         return {};
     },
     run: async (runRequest) => {
+        // Make sure we have a sufficiently recent version of Firebot.
+        if (!runRequest || !runRequest.firebot || !runRequest.firebot.version) {
+            throw new Error("Firebot version information is not available.");
+        }
+
+        const firebotVersion = runRequest.firebot.version;
+        const firebotParts = firebotVersion.split('.');
+        const majorVersion = parseInt(firebotParts[0], 10);
+        const minorVersion = parseInt(firebotParts[1] || '0', 10);
+        if (isNaN(majorVersion) || isNaN(minorVersion) || majorVersion < 5 || (majorVersion === 5 && minorVersion < 65)) {
+            const { frontendCommunicator } = runRequest.modules;
+            frontendCommunicator.send("error", `The installed version of Mage Trivia Game requires Firebot 5.65 or later. You are running Firebot ${firebotVersion}. Please update Firebot to use this game.`);
+            return;
+        }
+
         // Set our run request variable for use throughout the app.
         const firebotManager = new FirebotManager(runRequest);
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,7 +25,6 @@ export type GameSettings = {
         confirmationInterval: number;
         persistAskedQuestionsToFile: boolean;
         recycleQuestions: boolean;
-        enableTriviaErrorFull: boolean;
     };
 };
 
@@ -395,18 +394,6 @@ export function gameSettings(): Record<string, SettingCategoryDefinition> {
                     tip: "Applies only to the File source.",
                     default: true,
                     sortRank: 4,
-                    showBottomHr: true,
-                    validation: {
-                        required: true
-                    }
-                },
-                enableTriviaErrorFull: {
-                    type: "boolean",
-                    title: "Enable the $mageTriviaErrorFullDONOTUSETHISINCHAT variable",
-                    description: "We're just making sure you understand the implications of using this variable.",
-                    tip: "This variable can contain sensitive information, which could dox you if you use it in a chat message. Tread carefully.",
-                    default: false,
-                    sortRank: 5,
                     showBottomHr: true,
                     validation: {
                         required: true

--- a/src/variables/errors.ts
+++ b/src/variables/errors.ts
@@ -2,7 +2,6 @@ import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effect
 import { ReplaceVariable } from '@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager';
 import { TRIVIA_EVENT_SOURCE_ID, TriviaEvent } from '../events';
 import { logger } from '../firebot';
-import { triviaGame } from '../globals';
 
 export const mageTriviaError: ReplaceVariable = {
     definition: {
@@ -30,9 +29,11 @@ export const mageTriviaError: ReplaceVariable = {
 
 export const mageTriviaErrorFull: ReplaceVariable = {
     definition: {
-        handle: "mageTriviaErrorFullDONOTUSETHISINCHAT",
+        handle: "mageTriviaErrorFull",
+        aliases: ["mageTriviaErrorFullDONOTUSETHISINCHAT"],
         description: "Returns the full error message if an error occurred in the trivia game. CAUTION: THIS MAY CONTAIN SENSITIVE INFORMATION AND SHOULD NOT BE USED IN CHAT.",
         possibleDataOutput: ["text"],
+        sensitive: true,
         triggers: {
             "manual": true,
             "event": [
@@ -44,24 +45,16 @@ export const mageTriviaErrorFull: ReplaceVariable = {
     evaluator: async (trigger: Effects.Trigger) => {
         const safeMessage = trigger.metadata.eventData?.safeMessage as string;
         if (!safeMessage) {
-            logger('warn', `Called mageTriviaErrorFullDONOTUSETHISINCHAT variable without error message. ${JSON.stringify(trigger.metadata)}`);
+            logger('warn', `Called mageTriviaErrorFull variable without error message. ${JSON.stringify(trigger.metadata)}`);
             return "";
         }
 
-        let fullMessage = trigger.metadata.eventData?.message as string;
+        const fullMessage = trigger.metadata.eventData?.message as string;
         if (!fullMessage || fullMessage === "" || fullMessage === safeMessage) {
             return safeMessage;
         }
 
-        // If the user has not enabled the "Show Full Error Messages" setting,
-        // we should not return the full error message.
-        const triviaSettings = triviaGame.getFirebotManager().getGameSettings();
-        if (!triviaSettings.otherSettings.enableTriviaErrorFull) {
-            logger('warn', `Called mageTriviaErrorFullDONOTUSETHISINCHAT variable but the user has not enabled the "Show Full Error Messages" setting. ${JSON.stringify(trigger.metadata)}`);
-            fullMessage = "(To see the full error, read the documentation or look in the Firebot logs.)";
-        }
-
-        logger('debug', `mageTriviaErrorFullDONOTUSETHISINCHAT: ${safeMessage} ${fullMessage}`);
+        logger('debug', `mageTriviaErrorFull: ${safeMessage} ${fullMessage}`);
         return `${safeMessage} ${fullMessage}`;
     }
 };


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Marks the "full error message" variable as sensitive, which displays a built-in warning in Firebot 5.65. This also bumps the minimum version of Firebot to 5.65 as a result.

### Motivation
The previous implementation was a hack. This is the Firebot pattern going forward.

### Testing
Verified that the variable in question appears as sensitive.
